### PR TITLE
Use "-" char as filename for reading from stdin

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,7 @@
 "-p\tDestination UDP port\n"\
 "-a\tAudio driver [" HELP_AUDIO_DRIVERS "]\n"  HELP_AUDIO_DEVICE\
 "-c\tSound channels [stereo,mono,left,right] (default stereo)\n"\
-"-f\tFull path to 48kHz raw audio file. Use \"-\" for stdin\n"\
+"-f\tFull path to 48kHz raw audio file. Use \"-\" for stdin.\n"\
 "-l\tLog sound levels to console (stderr)\n"\
 "-d\tLog NMEA sentences to console (stderr)\n"\
 "-H\tDisplay this help\n"

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,7 @@
 "-p\tDestination UDP port\n"\
 "-a\tAudio driver [" HELP_AUDIO_DRIVERS "]\n"  HELP_AUDIO_DEVICE\
 "-c\tSound channels [stereo,mono,left,right] (default stereo)\n"\
-"-f\tFull path to 48kHz raw audio file. Use \"-\" for stdin.\n"\
+"-f\tFull path to 48kHz raw audio file. Use \"-\" for stdin. \n"\
 "-l\tLog sound levels to console (stderr)\n"\
 "-d\tLog NMEA sentences to console (stderr)\n"\
 "-H\tDisplay this help\n"

--- a/src/main.c
+++ b/src/main.c
@@ -62,7 +62,7 @@
 "-p\tDestination UDP port\n"\
 "-a\tAudio driver [" HELP_AUDIO_DRIVERS "]\n"  HELP_AUDIO_DEVICE\
 "-c\tSound channels [stereo,mono,left,right] (default stereo)\n"\
-"-f\tFull path to 48kHz raw audio file\n"\
+"-f\tFull path to 48kHz raw audio file. Use \"-\" for stdin\n"\
 "-l\tLog sound levels to console (stderr)\n"\
 "-d\tLog NMEA sentences to console (stderr)\n"\
 "-H\tDisplay this help\n"

--- a/src/sounddecoder.c
+++ b/src/sounddecoder.c
@@ -80,7 +80,15 @@ int initSoundDecoder(const Sound_Channels _channels, const Sound_Driver _driver,
     case DRIVER_FILE:
         strncpy(soundFile, file, MAX_FILENAME_SIZE);
         soundFile[MAX_FILENAME_SIZE]=0;
-        fp = fopen(soundFile, "rb");
+        if(soundFile[0]=='-'){
+			fp=stdin;
+#ifdef WIN32
+		    setmode(fileno(stdin), O_BINARY); // Binary mode
+#endif
+        }
+	    else{
+            fp = fopen(soundFile, "rb");
+	    }
         if (fp) {
             buffer_l = 1024;
             int extra = buffer_l % 5;


### PR DESCRIPTION
As no "/dev/stdin" file on windows, use the "-" character as filename for piping data into aisdecoder.
Windows compatibility added changing the stdin file mode to binary, avoiding DOS text translation to the piped data.
